### PR TITLE
Update .gitignore for local planning docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ serviceAccountKey.json
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local planning/docs (keep local-only)
+AGENTS.md
+CODEBASE_DEBT_BACKLOG.md
+SEO_30_DAY_RANKING_PLAN.md


### PR DESCRIPTION
## Summary
- Add local planning/docs files to .gitignore:
  - AGENTS.md
  - CODEBASE_DEBT_BACKLOG.md
  - SEO_30_DAY_RANKING_PLAN.md

## Why
These files should remain local-only and not be tracked in main.
